### PR TITLE
Change how markdown code is rendered

### DIFF
--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -35,6 +35,8 @@
 	code {
 		font-size: 85%;
 		background: $gray-lightest;
+		color: #CD3462;
+		padding: 3px;
 	}
 	pre {
 		border: 1px solid lighten($gray, 20%);


### PR DESCRIPTION
Code in the preview mode is now rendered pink and has 3px of padding around it